### PR TITLE
fix: improve Redgif embedding and NSFW gating for card and expanded views

### DIFF
--- a/app/src/components/ExpandedFeedMedia.test.tsx
+++ b/app/src/components/ExpandedFeedMedia.test.tsx
@@ -8,6 +8,7 @@ const mockExtractRedditGalleryUrl = jest.fn();
 const mockExtractRedditVideoPostUrl = jest.fn();
 const mockFetchRedditPostMedia = jest.fn();
 const mockExtractGifEmbedUrl = jest.fn();
+const mockExtractGifEmbedUrlFromContent = jest.fn();
 
 jest.mock("../redditGallery", () => {
   class MockRedditFetchError extends Error {
@@ -33,6 +34,8 @@ jest.mock("../redditGallery", () => {
 
 jest.mock("../gifUtils", () => ({
   extractGifEmbedUrl: (...args: unknown[]) => mockExtractGifEmbedUrl(...args),
+  extractGifEmbedUrlFromContent: (...args: unknown[]) =>
+    mockExtractGifEmbedUrlFromContent(...args),
 }));
 
 jest.mock("../context/ThemeContext", () => ({
@@ -87,6 +90,7 @@ describe("ExpandedFeedMedia", () => {
       success(1080, 1080);
     });
     mockExtractGifEmbedUrl.mockReturnValue(null);
+    mockExtractGifEmbedUrlFromContent.mockReturnValue(null);
     mockExtractRedditVideoPostUrl.mockReturnValue(null);
     mockExtractRedditGalleryUrl.mockReturnValue(null);
     mockFetchRedditPostMedia.mockResolvedValue({ images: [], video: null });
@@ -524,6 +528,34 @@ describe("ExpandedFeedMedia", () => {
     });
     expect(preview.props.blurRadius).toBe(0);
     expect(preview.props.autoplay).toBe(false);
+  });
+
+  it("detects a Redgifs embed URL from HTML content when itemUrl is not a gif host", async () => {
+    // Arrange — itemUrl is a Reddit thread, but content contains a Redgifs href
+    mockExtractGifEmbedUrl.mockReturnValue(null);
+    mockExtractGifEmbedUrlFromContent.mockReturnValue(
+      "https://www.redgifs.com/ifr/ContentGif"
+    );
+
+    let tree: renderer.ReactTestRenderer;
+
+    // Act
+    await act(async () => {
+      tree = renderer.create(
+        <ExpandedFeedMedia
+          itemUrl="https://www.reddit.com/r/test/comments/abc123"
+          content='<p><a href="https://www.redgifs.com/watch/ContentGif">view</a></p>'
+          testID="expanded-media"
+          deferGifLoad
+        />
+      );
+    });
+
+    // Assert — the GIF placeholder is shown (not a static image)
+    const loadButton = tree!.root.findByProps({
+      accessibilityLabel: "Load GIF",
+    });
+    expect(loadButton.props.testID).toBe("expanded-media");
   });
 
   it("renders a Reddit video play stage and switches to a player on tap", async () => {

--- a/app/src/components/ExpandedFeedMedia.tsx
+++ b/app/src/components/ExpandedFeedMedia.tsx
@@ -28,7 +28,7 @@ import {
   RedditFetchError,
   RedditVideoMedia,
 } from "../redditGallery";
-import { extractGifEmbedUrl } from "../gifUtils";
+import { extractGifEmbedUrl, extractGifEmbedUrlFromContent } from "../gifUtils";
 import { proxiedImageUrl } from "../proxyFetch";
 import { useTheme } from "../context/ThemeContext";
 import {
@@ -111,7 +111,10 @@ export function ExpandedFeedMedia({
     [itemUrl, content]
   );
   const redditPostUrl = redditGalleryUrl ?? redditVideoPostUrl;
-  const gifEmbedUrl = useMemo(() => extractGifEmbedUrl(itemUrl), [itemUrl]);
+  const gifEmbedUrl = useMemo(
+    () => extractGifEmbedUrl(itemUrl) ?? extractGifEmbedUrlFromContent(content),
+    [itemUrl, content]
+  );
   const shouldLoadGallery = Boolean(redditPostUrl) && hasRequestedGalleryLoad;
 
   useEffect(() => {

--- a/app/src/components/FeedPostCard.tsx
+++ b/app/src/components/FeedPostCard.tsx
@@ -16,7 +16,7 @@ import {
   extractRedditGalleryUrl,
   fetchRedditGalleryImageUrlsCached,
 } from "../redditGallery";
-import { extractGifEmbedUrl } from "../gifUtils";
+import { extractGifEmbedUrl, extractGifEmbedUrlFromContent } from "../gifUtils";
 import { ExpandedFeedMedia } from "./ExpandedFeedMedia";
 import { MetaText } from "./ui";
 import { fonts, fontSize, NSFW_BLUR_RADIUS, radii, spacing } from "../theme";
@@ -114,8 +114,12 @@ function FeedPostCardComponent({
   );
   const isRedditGallery = Boolean(redditGalleryUrl);
   const isGif = useMemo(
-    () => Boolean(extractGifEmbedUrl(item.url)),
-    [item.url]
+    () =>
+      Boolean(
+        extractGifEmbedUrl(item.url) ??
+          extractGifEmbedUrlFromContent(item.content)
+      ),
+    [item.url, item.content]
   );
   const showCardRevealOverlay = isCardMediaBlurred;
   // For card NSFW galleries we want to show the first image (blurred) under
@@ -155,7 +159,7 @@ function FeedPostCardComponent({
               blur={showCardRevealOverlay}
               nsfw={nsfw}
               deferGalleryLoad={cardGalleryDeferred}
-              deferGifLoad={isGif && (!nsfw || !cardMediaRevealed)}
+              deferGifLoad={isGif}
               useProxy={useProxy}
             />
             {showCardRevealOverlay ? (

--- a/app/src/components/FeedPostCard.tsx
+++ b/app/src/components/FeedPostCard.tsx
@@ -117,7 +117,7 @@ function FeedPostCardComponent({
     () =>
       Boolean(
         extractGifEmbedUrl(item.url) ??
-          extractGifEmbedUrlFromContent(item.content)
+        extractGifEmbedUrlFromContent(item.content)
       ),
     [item.url, item.content]
   );

--- a/app/src/gifUtils.test.ts
+++ b/app/src/gifUtils.test.ts
@@ -1,5 +1,6 @@
 import {
   extractGifEmbedUrl,
+  extractGifEmbedUrlFromContent,
   extractGiphyId,
   extractRedgifsId,
   getGiphyEmbedUrl,
@@ -121,5 +122,46 @@ describe("extractGifEmbedUrl", () => {
 
   it("returns null for null input", () => {
     expect(extractGifEmbedUrl(null)).toBeNull();
+  });
+});
+
+describe("extractGifEmbedUrlFromContent", () => {
+  it("finds a Redgifs embed URL from an href in HTML content", () => {
+    expect(
+      extractGifEmbedUrlFromContent(
+        '<p><a href="https://www.redgifs.com/watch/TightGif">view</a></p>'
+      )
+    ).toBe("https://www.redgifs.com/ifr/TightGif");
+  });
+
+  it("finds a Giphy embed URL from an href in HTML content", () => {
+    expect(
+      extractGifEmbedUrlFromContent(
+        '<p><a href="https://giphy.com/gifs/cat-xT9IgG50Lg7KXYNX8I">view</a></p>'
+      )
+    ).toBe("https://giphy.com/embed/xT9IgG50Lg7KXYNX8I");
+  });
+
+  it("returns null when content has no gif links", () => {
+    expect(
+      extractGifEmbedUrlFromContent("<p>No gif links here</p>")
+    ).toBeNull();
+  });
+
+  it("returns null for null input", () => {
+    expect(extractGifEmbedUrlFromContent(null)).toBeNull();
+  });
+
+  it("returns null for undefined input", () => {
+    expect(extractGifEmbedUrlFromContent(undefined)).toBeNull();
+  });
+
+  it("returns the first gif link when multiple hrefs are present", () => {
+    expect(
+      extractGifEmbedUrlFromContent(
+        '<a href="https://www.redgifs.com/watch/FirstGif">1</a>' +
+          '<a href="https://www.redgifs.com/watch/SecondGif">2</a>'
+      )
+    ).toBe("https://www.redgifs.com/ifr/FirstGif");
   });
 });

--- a/app/src/gifUtils.ts
+++ b/app/src/gifUtils.ts
@@ -107,3 +107,19 @@ export function extractGifEmbedUrl(
 
   return null;
 }
+
+/**
+ * Scans HTML content for the first href attribute pointing to a Redgifs or
+ * Giphy URL and returns its embed URL, or null if none is found.
+ * Useful for Reddit self-posts that embed a GIF link in the post body.
+ */
+export function extractGifEmbedUrlFromContent(
+  content: string | null | undefined
+): string | null {
+  if (!content) return null;
+  for (const match of content.matchAll(/href="([^"]+)"/gi)) {
+    const embedUrl = extractGifEmbedUrl(match[1]);
+    if (embedUrl) return embedUrl;
+  }
+  return null;
+}

--- a/app/src/screens/FeedItemScreen.tsx
+++ b/app/src/screens/FeedItemScreen.tsx
@@ -363,6 +363,7 @@ export default function FeedItemScreen({ route, navigation }: Props) {
               useProxy={item.useProxy ?? false}
               nsfw={item.nsfw ?? false}
               deferGalleryLoad={false}
+              deferGifLoad={item.nsfw ?? false}
             />
           ) : null}
 

--- a/app/src/screens/FeedListScreen.test.tsx
+++ b/app/src/screens/FeedListScreen.test.tsx
@@ -937,7 +937,7 @@ describe("FeedListScreen", () => {
     });
   });
 
-  it("shows reveal overlay for NSFW GIFs in card layout and auto-loads GIF after reveal", async () => {
+  it("shows reveal overlay for NSFW GIFs in card layout and shows Load GIF pill after reveal", async () => {
     // Arrange
     (loadConfig as jest.Mock).mockReturnValue({ feedLayout: "card" });
     (getFeeds as jest.Mock).mockResolvedValue([
@@ -1006,13 +1006,13 @@ describe("FeedListScreen", () => {
       await revealButton.props.onPress();
     });
 
-    // Assert: overlay is gone and GIF is no longer deferred
+    // Assert: overlay is gone and GIF is still deferred (user must tap "Load GIF")
     expect(
       mockExpandedFeedMedia.mock.calls.some(
         ([props]) =>
           props.testID === "card-media-701" &&
           props.blur === false &&
-          props.deferGifLoad === false
+          props.deferGifLoad === true
       )
     ).toBe(true);
 


### PR DESCRIPTION
- Add extractGifEmbedUrlFromContent to detect Redgifs/Giphy links in Reddit
  self-post body HTML, mirroring how gallery/video detection already checks
  content alongside itemUrl
- Fix card view: always defer GIF load (deferGifLoad={isGif}) so NSFW reveal
  shows "Load GIF" pill instead of auto-playing the embed — consistent with
  how NSFW videos require an explicit "Play video" tap after reveal
- Fix expanded view: pass deferGifLoad={item.nsfw} so NSFW Redgifs in the
  detail screen prompt "NSFW GIF. Tap to load." instead of auto-playing
- Update tests to reflect the corrected NSFW GIF deferral behaviour

https://claude.ai/code/session_01K6gDVJmHzVzhUyxMS8huM9